### PR TITLE
MVA friend trees from separate files (*_mva.root)

### DIFF
--- a/plots/common/sample.py
+++ b/plots/common/sample.py
@@ -79,6 +79,11 @@ class Sample:
             self.tree.AddFriend("trees/MVA")
         #self.tree.AddBranchToCache("*", 1)
 
+        # add friend tree from another file containing mva values
+        self.file_name_mva = file_name[:-5] + "_mva.root"
+        if os.path.isfile(self.file_name_mva):
+            self.tree.AddFriend("trees/MVA", self.file_name_mva)
+        
         self.event_count = None
         self.event_count = self.getEventCount()
         if self.event_count<=0:

--- a/plots/common/utils.py
+++ b/plots/common/utils.py
@@ -46,6 +46,9 @@ def get_file_list(merge_cmds, dir, fullpath=True, permissive=True):
     if not fullpath:
         out_files = map(lambda x: x.split("/")[-1], out_files)
 
+    # remove files ending in _mva.root, which contain friend trees with mva outputs
+    out_files = filter(lambda x: not x.endswith("_mva.root"), out_files)
+    
     #If you called this method and got nothing, then probably womething went wrong and you don't want the output
     if len(out_files)==0 and not permissive:
         raise Exception("Couldn't match any files to merge_cmds %s in directory %s" % (str(merge_cmds), dir))


### PR DESCRIPTION
We propose the following changes to `plots.common` so that MVA values could be loaded from separate ROOT files that are placed next to the sample files, but have a `_mva` suffix.

The MVA trees (in TFile the tree `trees/MVA`) are added with AddFriend.

In the `plots.common.sample.get_file_list` function we filter out the `*_mva.root` files so that they would not be returned by the function.
