### PR TITLE
Cmssw gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ CMSSW_5_3_11/src/*
 CMSSW_5_3_11/src/PhysicsTools/PatAlgos
 CMSSW_5_3_11/src/PhysicsTools/PatUtils
 
+# The automatically downloaded exempi tool
+exempi-2.2.1.tar.bz2
+exempi-2.2.1
+
 /bin/*
 *.png
 *.pickle


### PR DESCRIPTION
Ignore everything in `CMSSW_5_3_11` except the following directories:
- `CMSSW_5_3_11/src/SingleTopPolarization`
- `CMSSW_5_3_11/src/data`
- `CMSSW_5_3_11/src/PhysicsTools`

Also ignore the `PatAlgos` and `PatUtils` packages in `PhysicsTools`, since they seem to be automatically downloaded.

It is interesting that the `CMSSW_5_3_11/config` is completely ignored, although it has files that are in the repo. However since it was explicitly ignored before, I did not change that behavior.

Finally, ignore the `exempi-2.2.1` directory and tar as well.
